### PR TITLE
Fixed GitHub link button

### DIFF
--- a/_includes/sections/contribute.html
+++ b/_includes/sections/contribute.html
@@ -1,7 +1,9 @@
 <div class="section section__contribute">
   <div class="wrapper">
     <h2>We’re looking for contributors!</h2>
-    <a href="https://github.com/amalgam8"><div class="button">Join Us On Github</div></a>
+    <div class="github-wrapper">
+    	<a href="https://github.com/amalgam8"><div class="button">Join Us On Github</div></a>
+    </div>
     <img src="/assets/heart.svg" alt="An image of a heart with a mouse cursor implying a click">
   </div>
 </div>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -281,12 +281,23 @@ a{
   align-items: center;
   text-align: center;
 
-  a{
+  .github-wrapper{
     display: flex;
-    justify-content: center;;
     padding-top: 2rem;
     padding-bottom: 2rem;
+    justify-content: center;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  a{
+    display: flex;
+    justify-content: center;
     text-decoration: none;
+    width: 100%;
+    max-width: 20rem;
 
     &:hover{
       color: $pink;


### PR DESCRIPTION
GitHub link click area was spilling over into parent div. Added `github-wrapper` div and updated styling to contain click area to `button` div.
