### PR TITLE
Fixed typo with intro doc

### DIFF
--- a/_docs/0-intro.md
+++ b/_docs/0-intro.md
@@ -50,7 +50,7 @@ orchestration layer
 
 **[Amalgam8 Sidecar](/docs/sidecar/):** Amalgam8 uses the sidecar model or
 the ambassador pattern for building microservices applications. The sidecar
-runs as in independent process and takes care of service registration,
+runs as an independent process and takes care of service registration,
 discovery and request routing to various microservices. The sidecar model
 simplifies development of polyglot applications.
 


### PR DESCRIPTION
found a small typo within the 0-intro.md doc file. Felt it was faster to fix it and open up a PR than open up an issue for it.

in -> an
