### PR TITLE
removed try it out button

### DIFF
--- a/_layouts/swaggerui.html
+++ b/_layouts/swaggerui.html
@@ -44,7 +44,7 @@ layout: api
       window.swaggerUi = new SwaggerUi({
         url: url,
         dom_id: "swagger-ui-container",
-        supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+        supportedSubmitMethods: [],
         onComplete: function(swaggerApi, swaggerUi){
           if(typeof initOAuth == "function") {
             initOAuth({


### PR DESCRIPTION
@rshriram this should close #80 .

screen shot of API docs without button
![swagger-ui-no-button](https://cloud.githubusercontent.com/assets/10573505/19336737/7adc4c88-90d3-11e6-87c7-431d999c1d3a.png)

also if interested, i was having trouble with `vagrant up` so i created a docker file that allows the site to run in a container. used it for testing and bring up was pretty fast. if you are interested, i can drop it as another PR with instructions how to build/run it. just let me know.
