### PR TITLE
convert all pages to html links

### DIFF
--- a/_docs/0-intro.md
+++ b/_docs/0-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Amalgam8 Concepts
-permalink: /docs/amalgam8-microservice-routing/
+permalink: /docs/amalgam8-microservice-routing.html
 order: 0
 ---
 
@@ -48,17 +48,17 @@ orchestration layer
 [Marathon](https://mesosphere.github.io/marathon/)) or the cloud platform
 (Amazon AWS, IBM Bluemix, Google Cloud Platform, Microsoft Azure, etc.
 
-**[Amalgam8 Sidecar](/docs/sidecar/):** Amalgam8 uses the sidecar model or
+**[Amalgam8 Sidecar](/docs/sidecar.html):** Amalgam8 uses the sidecar model or
 the ambassador pattern for building microservices applications. The sidecar
 runs as an independent process and takes care of service registration,
 discovery and request routing to various microservices. The sidecar model
 simplifies development of polyglot applications.
 
-**[Amalgam8 Control Plane](/docs/control-plane/):** The microservice runtime
+**[Amalgam8 Control Plane](/docs/control-plane.html):** The microservice runtime
 management layer, called the Amalgam8 Control Plane, can be used to
 dynamically program the sidecars in each microservice and control how
 requests are routed between microservices. It consists of a [Route
-Controller](/docs/control-plane/controller/) and a [Service Registry](/docs/control-plane/registry/).
+Controller](/docs/control-plane-controller.html) and a [Service Registry](/docs/control-plane-registry.html).
 
 The following diagram illustrates how these components work together:
 
@@ -66,7 +66,7 @@ The following diagram illustrates how these components work together:
 
 1. Microservice instances are registered in the service registry by the
    sidecars. There are several ways this may be accomplished as described in
-   [Amalgam8 Registry](/docs/control-plane/registry/).
+   [Amalgam8 Registry](/docs/control-plane-registry.html).
 
 2. The Developer uses the control plane API to configure high-level rules
    for request routing between services (e.g., splitting traffic across

--- a/_docs/1-demo/bookinfo.md
+++ b/_docs/1-demo/bookinfo.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Bookinfo
-permalink: /docs/demo/bookinfo/
+permalink: /docs/demo-bookinfo.html
 category: Demo
 order: 3
 ---
@@ -30,7 +30,7 @@ The end-to-end architecture of the application is shown below.
 
 This application is polyglot, i.e., the microservices are written in
 different languages. All microservices are packaged with the
-[Amalgam8 Sidecar](/doc/sidecar/) that provides automatic service
+[Amalgam8 Sidecar](/docs/sidecar.html) that provides automatic service
 registration. For microservices that need to make outbound API
 calls, i.e., `productpage` and `reviews`, the sidecar acts as a proxy
 routing requests to appropriate instances of upstream services, based on

--- a/_docs/1-demo/helloworld.md
+++ b/_docs/1-demo/helloworld.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Hello World!
-permalink: /docs/demo/helloworld/
+permalink: /docs/demo-helloworld.html
 category: Demo
 order: 2
 ---

--- a/_docs/1-demo/intro.md
+++ b/_docs/1-demo/intro.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Introduction
-permalink: /docs/demo/
+permalink: /docs/demo.html
 category: Demo
 order: 0
 ---
@@ -9,7 +9,7 @@ order: 0
 This guide illustrates how to use Amalgam8 for version and content-based
 routing using two demo applications. The guide is divided into two parts:
 
-1. [Setup](/docs/demo/setup/). This section provides step-by-step
+1. [Setup](/docs/demo-setup.html). This section provides step-by-step
    instructions on how to get the Amalgam8 control plane and the CLI
    installed and configured for different container runtimes locally
    ([Docker](https://www.docker.com), [Kubernetes](https://kubernetes.io))
@@ -20,12 +20,12 @@ routing using two demo applications. The guide is divided into two parts:
 2. **Example Apps:** Two example applications are provided to illustrate
    various features of Amalgam8.
 
-    1. [Helloworld](/docs/demo/helloworld/). A simple application
+    1. [Helloworld](/docs/demo-helloworld.html). A simple application
        with one microservice. We will use this example app to illustrate
        how Amalgam8 provides _version-based routing with weighted load
        balancing between two different versions of the same microservice_.
 
-    2. [Bookinfo](/docs/demo/bookinfo/). A polyglot application
+    2. [Bookinfo](/docs/demo-bookinfo.html). A polyglot application
        with 4 microservices written using Python, Ruby and Java. We 
        will use this app to illustrate several features of Amalgam8 such as
        _content-based routing across different microservice versions,

--- a/_docs/1-demo/setup.md
+++ b/_docs/1-demo/setup.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Setup
-permalink: /docs/demo/setup/
+permalink: /docs/demo-setup.html
 category: Demo
 order: 1
 ---
@@ -44,8 +44,8 @@ running Amalgam8.
 ## Setting up the Control Plane
 
 The Amalgam8 Control Plane consists of two components: the
-[service registry](/docs/control-plane/registry/) and the
-[route controller](/docs/control-plane/controller/).  In addition to these two
+[service registry](/docs/control-plane-registry.html) and the
+[route controller](/docs/control-plane-controller.html).  In addition to these two
 components, for the purposes of this demo, a stock ELK stack is also
 included as part of the control plane deployment scripts, to collect logs
 from the microservices in the application.

--- a/_docs/2-controlplane/0-intro.md
+++ b/_docs/2-controlplane/0-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Introduction
-permalink: /docs/control-plane/
+permalink: /docs/control-plane.html
 category: Control Plane
 order: 0
 ---
@@ -11,7 +11,7 @@ view of the microservices in the application and how they are communicating
 with each other. It consists of two multi-tenant services:
 
 1. **Route Controller** manages how requests are routed across
-   microservices via the [Amalgam8 Sidecars](/docs/sidecar/). Routes
+   microservices via the [Amalgam8 Sidecars](/docs/sidecar.html). Routes
    programmed at the controller are percolated down to the sidecars
    periodically. Routing rules can be based on the content of the requests
    and the version of microservices sending and receiving the requests. In
@@ -28,6 +28,6 @@ with each other. It consists of two multi-tenant services:
 Please refer to the following subsections for more details
 on how to setup and operate the services in the control plane:
 
-* [Route Controller](/docs/control-plane/controller/)
+* [Route Controller](/docs/control-plane-controller.html)
 
-* [Service Registry](/docs/control-plane/registry/)
+* [Service Registry](/docs/control-plane-registry.html)

--- a/_docs/2-controlplane/1-controller/configuration-options.md
+++ b/_docs/2-controlplane/1-controller/configuration-options.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Configuration
-permalink: /docs/control-plane/controller/controller-configuration-options/
+permalink: /docs/control-plane-controller-configuration.html
 category: Control Plane
 subcategory: Route Controller
 order: 1
@@ -29,6 +29,13 @@ The following environment variables are available. All of them are optional.
 | | --help, -h | show help | |
 | | --version, -v | print the version | |
 {:.table .table-bordered .table-condensed .table-striped}
+
+## Authentication and Multi-tenancy
+
+The Amalgam8 Registry supports multi-tenancy by isolating each tenant into
+a separate namespace.  Refer to the
+[Authentication](/docs/control-plane-authentication.html) section 
+for further details.
 
 ## Example Configuration using Environment Variables
 

--- a/_docs/2-controlplane/1-controller/intro.md
+++ b/_docs/2-controlplane/1-controller/intro.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Introduction
-permalink: /docs/control-plane/controller/
+permalink: /docs/control-plane-controller.html
 category: Control Plane
 subcategory: Route Controller
 order: 0
@@ -15,11 +15,11 @@ canary and red/black deployments, A/B testing, and systematically testing resili
 
 The rest of this guide is organized as follows:
 
-* [A8 Rules API](/docs/control-plane/controller/rules-api/) section describes
+* [A8 Rules API](/docs/control-plane-controller-rules-api.html) section describes
   the API used to manage routing and other action rules.
   
-* [A8 Rules DSL](/docs/control-plane/controller/rules-dsl/) section describes
+* [A8 Rules DSL](/docs/control-plane-controller-rules-dsl.html) section describes
   the Amalgam8 DSL (Domain Specific Language) used to represent rules in the API.
   
-* [Configuration](/docs/control-plane/controller/controller-configuration-options/) section provides
+* [Configuration](/docs/control-plane-controller-configuration.html) section provides
   details on running and configuration of the controller service in the control-plane.

--- a/_docs/2-controlplane/1-controller/rules-api.md
+++ b/_docs/2-controlplane/1-controller/rules-api.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: A8 Rules REST API
-permalink: /docs/control-plane/controller/rules-api/
+permalink: /docs/control-plane-controller-rules-api.html
 category: Control Plane
 subcategory: Route Controller
 order: 2
@@ -11,7 +11,7 @@ Rule definitions are managed via the Amalgam8 controller's REST API.
 A simple commandline interface that calls this REST API is available for basic use cases.
 The CLI documentation is available [here](https://github.com/amalgam8/a8ctl). 
 However, for more advanced functionality or defining rules programmatically, the controller API supports a 
-powerful [Rules DSL](/docs/control-plane/controller/rules-dsl/) and can be called directly. 
+powerful [Rules DSL](/docs/control-plane-controller-rules-dsl.html) and can be called directly. 
 
 The following describes basic invocation of the controller REST API using `curl` with the utility `jq` to format the output `json`. For these commands we assume that the controller is running in global authorization mode so that no authentication is required.
 
@@ -178,7 +178,7 @@ curl -i -X DELETE <controller URL>/v1/rules
 
 Detailed documentation on the route controller's REST API can be found [here](/api/controller/).
 
-Rules passed to the controller conform to the [A8 Rules DSL](/docs/control-plane/controller/rules-dsl/) and
+Rules passed to the controller conform to the [A8 Rules DSL](/docs/control-plane-controller-rules-dsl.html) and
 are validated against a [JSON schema](http://json-schema.org/) definition that is available [here](/api/controller-rules-schema/).
 
 ## Service references in rules vs services registered in registry

--- a/_docs/2-controlplane/1-controller/rules-dsl.md
+++ b/_docs/2-controlplane/1-controller/rules-dsl.md
@@ -1,13 +1,13 @@
 ---
 layout: page
 title: A8 Rules DSL
-permalink: /docs/control-plane/controller/rules-dsl/
+permalink: /docs/control-plane-controller-rules-dsl.html
 category: Control Plane
 subcategory: Route Controller
 order: 3
 ---
 
-The Amalgam8 controller [API for managing rules](/docs/control-plane/controller/rules-api/) uses a Rules DSL based on JSON.
+The Amalgam8 controller [API for managing rules](/docs/control-plane-controller-rules-api.html) uses a Rules DSL based on JSON.
 For example, a simple rule to send 100% of incoming traffic for the "reviews" microservice
 to version "v1" can be described using the Rules DSL as follows.
 
@@ -51,7 +51,6 @@ but must rather be represented using two seperate rules in the DSL.
             * [route.backends.tags](#route-backends-tags)
             * [route.backends.weight](#route-backends-weight)
             * [route.backends.name](#route-backends-name)
-            * [route.backends.timeout](#route-backends-timeout)           
 * [Action Rules](#action-rules)
     * [actions](#actions)
         * [actions.action](#actions-action)
@@ -268,11 +267,6 @@ the "v2" tag and the remaining traffic (i.e., 75%) to "v1".
 
 The `name` field is optional and specifies the service name of the target instances. If not specified, it defaults
 to the value of the rule's `destination` field.
-
-#### Property: route.backends.timeout <a id="route-backends-timeout"></a>
-
-The last optional field of a backend object is `timeout` which is the time, in seconds, to wait for a backend to respond
-before timing out the request.
 
 ### Routing Rule Execution
 

--- a/_docs/2-controlplane/2-registry/configuration-options.md
+++ b/_docs/2-controlplane/2-registry/configuration-options.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Configuration
-permalink: /docs/control-plane/registry/registry-configuration-options/
+permalink: /docs/control-plane-registry-configuration.html
 category: Control Plane
 subcategory: Service Registry
 order: 1
@@ -31,9 +31,8 @@ The following environment variables are available. All of them are optional.
 ## Authentication and Multi-tenancy
 
 The Amalgam8 Registry supports multi-tenancy by isolating each tenant into
-a separate namespace.  It supports the same set of authentication
-mechanisms as the Route Controller. Please refer to the
-[Authentication & Multi-tenancy](/docs/control-plane/controller/controller-authentication/)
+a separate namespace.  Refer to the
+[Authentication](/docs/control-plane-authentication.html) section 
 for further details.
 
 ## Clustering
@@ -82,5 +81,5 @@ with the content of the Registry itself.
 | `A8_K8S_URL` | `--k8s_url` | Enable kubernetes catalog and specify the API server | (none) |
 | `A8_K8S_TOKEN` | `--k8s_token` | Kubernetes API token | (none) |
 | `A8_EUREKA_URL` | `--eureka_url` | Enable eureka catalog and specify the API server. Multiple API servers can be specified using multiple flags | (none) |
-| `A8_FS_CATALOG` | `--fs_catalog` | Enable FileSystem catalog and specify the directory of the config files. The format of the file names in the directory should be `<namespace>.conf`. See [File Catalog](/docs/control-plane/registry/file-catalog/) for more information | (none) |
+| `A8_FS_CATALOG` | `--fs_catalog` | Enable FileSystem catalog and specify the directory of the config files. The format of the file names in the directory should be `<namespace>.conf`. See [File Catalog](/docs/control-plane-registry-external-services.html) for more information | (none) |
 {:.table .table-bordered .table-condensed .table-striped}

--- a/_docs/2-controlplane/2-registry/eureka-compatibility.md
+++ b/_docs/2-controlplane/2-registry/eureka-compatibility.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Eureka API Compatibility
-permalink: /docs/control-plane/registry/eureka-compatibility/
+permalink: /docs/control-plane-registry-eureka-api-compatibility.html
 category: Control Plane
 subcategory: Service Registry
 order: 2

--- a/_docs/2-controlplane/2-registry/file-catalog.md
+++ b/_docs/2-controlplane/2-registry/file-catalog.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: File Catalog
-permalink: /docs/control-plane/registry/file-catalog/
+permalink: /docs/control-plane-registry-external-services.html
 category: Control Plane
 subcategory: Service Registry
 order: 3

--- a/_docs/2-controlplane/2-registry/intro.md
+++ b/_docs/2-controlplane/2-registry/intro.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Introduction
-permalink: /docs/control-plane/registry/
+permalink: /docs/control-plane-registry.html
 category: Control Plane
 subcategory: Service Registry
 order: 0
@@ -15,7 +15,7 @@ following diagram:
 ![basic registration](/docs/figures/amalgam8-service-registration.svg)
 
 **Registration, heartbeats and health checks**. The
-[Amalgam8 Sidecar](/docs/sidecar/) is used to register and continuously
+[Amalgam8 Sidecar](/docs/sidecar.html) is used to register and continuously
 send heartbeats to the registry on behalf of a microservice instance. In
 addition, the sidecar keeps track of the health of the application
 (microservice A in the figure above) and stops sending heartbeats if or
@@ -52,20 +52,20 @@ platform, etc.  This extends Amalgam8's benefits, such as resiliency
 testing, to include the full set of services used by the application.  To
 enable specifying routing rules on external services, they must first be
 visible via the Amalgam8 registry. The
-[File catalog](/docs/control-plane/registry/file-catalog/) can be used to register such
+[File catalog](/docs/control-plane-registry-external-services.html) can be used to register such
 external services with the registry.
 
 The rest of this guide is structured as follows:
 
-* [Eureka API Compatibility](/docs/control-plane/registry/eureka-compatibility) describes
+* [Eureka API Compatibility](/docs/control-plane-registry-eureka-api-compatibility.html) describes
   how to use the Amalgam8 Registry as a drop-in replacement for Netflix
   Eureka, and configure clients such as Ribbon or Spring Cloud applications
   that use the Eureka API.
 
-* [File Catalog](/docs/control-plane/registry/file-catalog/) describes how to use the
+* [File Catalog](/docs/control-plane-registry-external-services.html) describes how to use the
   file-based catalog to register external services such as third party
   APIs with the Amalgam8 Registry.
   
-* [Kubernetes Catalog](/docs/control-plane/registry/kubernetes-catalog/) describes how to
+* [Kubernetes Catalog](/docs/control-plane-registry-kubernetes-catalog.html) describes how to
   configure the Amalgam8 Registry to synchronize registration information
   from Kubernetes' built in service registry.

--- a/_docs/2-controlplane/2-registry/kubernetes-catalog.md
+++ b/_docs/2-controlplane/2-registry/kubernetes-catalog.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Kubernetes Catalog
-permalink: /docs/control-plane/registry/kubernetes-catalog/
+permalink: /docs/control-plane-registry-kubernetes-catalog.html
 category: Control Plane
 subcategory: Service Registry
 order: 4

--- a/_docs/2-controlplane/3-authentication.md
+++ b/_docs/2-controlplane/3-authentication.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Authentication
-permalink: /docs/control-plane/authentication/
+permalink: /docs/control-plane-authentication.html
 category: Control Plane
 order: 1
 ---

--- a/_docs/2-controlplane/4-ha-deployment.md
+++ b/_docs/2-controlplane/4-ha-deployment.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: High Availability
-permalink: /docs/control-plane/high-availability/
+permalink: /docs/control-plane-high-availability.html
 category: Control Plane
 order: 2
 ---

--- a/_docs/3-sidecar/configuration-options.md
+++ b/_docs/3-sidecar/configuration-options.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Configuration
-permalink: /docs/sidecar/sidecar-configuration-options/
+permalink: /docs/sidecar-configuration.html
 category: Sidecar
 order: 3
 ---
@@ -42,7 +42,11 @@ YAML file.
 
 ## Example configurations
 
-### Automatic service registration
+* [Service registration](#service-registration)
+* [Health checks](#health-checks)
+* [Request routing](#request-routing)
+
+### Service registration <a id="service-registration"></a>
 
 Registration and heartbeat with the Amalgam8 service registry 
 can be enabled by setting the following environment variables or 
@@ -74,7 +78,8 @@ registry:
   url:   http://registry:8080
 ```
 
-### Health checks
+  
+### Health checks <a id="health-checks"></a>
 
 In addition to automatic service registration,
 the sidecar can periodically check the health of the application at specified 
@@ -114,7 +119,8 @@ where
 
 Note that the sidecar will access the specified URL via the GET method only.
 
-### Request routing
+
+### Request routing <a id="request-routing"></a>
 
 For microservices that make outbound calls
 to other microservices, service discovery and client-side load balancing,

--- a/_docs/3-sidecar/deployment-options.md
+++ b/_docs/3-sidecar/deployment-options.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Deployment Options
-permalink: /docs/sidecar/deployment-options/
+permalink: /docs/sidecar-deployment-options.html
 category: Sidecar
 order: 1
 ---
@@ -34,8 +34,8 @@ like. The set of releases are available
 **Note:** The above script is intended for Debian and Ubuntu based docker images only.
 
 Make sure to launch the sidecar along with your application. The sidecar
-can be launched using the `a8sidecar` command. Please refer to the
-[configuration options](configuration-options/) page for details on how to
+can be launched using the `a8sidecar` command. Refer to the
+[configuration options](/docs/sidecar-configuration.html) page for details on how to
 configure the sidecar.
 
 A typical docker file will look like this:

--- a/_docs/3-sidecar/intro.md
+++ b/_docs/3-sidecar/intro.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Introduction
-permalink: /docs/sidecar/
+permalink: /docs/sidecar.html
 category: Sidecar
 order: 0
 ---
@@ -19,16 +19,16 @@ following functional components:
 
 The rest of this guide is organized as follows:
 
-* [Deployment Options](/docs/sidecar/deployment-options/) section describes
+* [Deployment Options](/docs/sidecar-deployment-options.html) section describes
   different ways of packaging the sidecar with a microservice (as part of a
   container or a pod)
   
-* [Usage](/docs/sidecar/usage/) section describes how to use the
+* [Usage](/docs/sidecar-usage.html) section describes how to use the
   sidecar as a proxy to make API calls to dependent microservices.
   
-* [Configuration](/docs/sidecar/sidecar-configuration-options/) section provides details on
+* [Configuration](/docs/sidecar-configuration.html) section provides details on
   various runtime configuration options while launching the sidecar, including
   automatic service registration, health checks, and request proxying.
 
-* [Logging](/docs/sidecar/sidecar-logging-api-calls/) describes how the sidecar logs the API 
-  calls and which log files need to be managed by the user.
+* [Logging](/docs/sidecar-logging-api-calls.html) describes how the
+  to monitor API calls made by the sidecar.

--- a/_docs/3-sidecar/sidecar-logging-api-calls.md
+++ b/_docs/3-sidecar/sidecar-logging-api-calls.md
@@ -1,15 +1,16 @@
 ---
 layout: page
 title: Logging
-permalink: /docs/sidecar/sidecar-logging-api-calls/
+permalink: /docs/sidecar-logging-api-calls.html
 category: Sidecar
 order: 6
 ---
 
 All logs pertaining to external API calls made by the Nginx
-proxy will be stored in `/var/log/nginx/a8_access.log` and
-`/var/log/nginx/error.log`. The access logs are stored in JSON format. Note
-that there is **no support for log rotation**. If you have a monitoring and
-logging system in place, it is advisable to propagate the request logs to
-your log storage system in order to take advantage of Amalgam8 features
-like resilience testing.
+proxy are be stored in `/var/log/nginx/a8_access.log` and
+`/var/log/nginx/error.log`. The access logs are stored in JSON format.
+
+Note that there is **no support for log rotation**. If you have a
+monitoring and logging system in place, it is advisable to propagate the
+request logs to your log storage system in order to take advantage of
+Amalgam8 features like resilience testing.

--- a/_docs/3-sidecar/using-the-amalgam8-sidecar.md
+++ b/_docs/3-sidecar/using-the-amalgam8-sidecar.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Usage
-permalink: /docs/sidecar/usage/
+permalink: /docs/sidecar-usage.html
 category: Sidecar
 order: 2
 ---

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -11,20 +11,20 @@ internal architecture.
 
 The documentation is structured as follows:
 
-* [Amalgam8 Concepts](/docs/amalgam8-microservice-routing/) describes
+* [Amalgam8 Concepts](/docs/amalgam8-microservice-routing.html) describes
   the fundamental concepts behind Amalgam8 and how Amalgam8 works in tandem
   with various container runtimes.
 
-* [Demo](/docs/demo/) section contains walkthroughs that illustrate
+* [Demo](/docs/demo.html) section contains walkthroughs that illustrate
   some of Amalgam8's key features using the sample applications available
   in the Amalgam8 GitHub repository.
 
-* [Control Plane](/docs/control-plane/) section provides detailed
+* [Control Plane](/docs/control-plane.html) section provides detailed
   information on the architecture, installation and configuration of the
   services in Amalgam8's management plane, namely the Service Registry and
   the Route Controller.
 
-* [Sidecar](/docs/sidecar/) section provides detailed information on
+* [Sidecar](/docs/sidecar.html) section provides detailed information on
   the architecture, installation and configuration of the Amalgam8 Sidecar
   that is responsible for service registration, heartbeat, service
   discovery, and intelligent request routing between microservices.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,6 @@
     <div class="footer-col-wrapper">
       <div class="footer-col-left">
         <ul class="contact-list">
-          <li><a href="/docs/what-is-amalgam8/">Intro</a></li>
           <li><a href="/docs/">Docs</a></li>
           <li><a href="/api/">API</a></li>
           <li><a href="https://github.com/{{site.github_username}}/amalgam8/releases"><i class="fa fa-lg fa-download"></i> Download</a></li>


### PR DESCRIPTION
Instead of having URLs like docs/sidecar/configurations/, convert the docs pages to a format like docs/sidecar-configurations.html
