### PR TITLE
Fix command health check specification.

### DIFF
--- a/_docs/3-sidecar/configuration-options.md
+++ b/_docs/3-sidecar/configuration-options.md
@@ -119,7 +119,7 @@ healthchecks:
     interval: 30s
     timeout: 3s
   - type: file
-    value: file:///opt/check_my_app.sh
+    value: /opt/check_my_app.sh
     interval: 10s
     timeout: 5s
 ```


### PR DESCRIPTION
Value should be the path of the command with out the `file://` scheme specification.