### PR TITLE
Using the minikube variables to find the IP.

### DIFF
--- a/_docs/1-demo/bookinfo.md
+++ b/_docs/1-demo/bookinfo.md
@@ -160,7 +160,8 @@ stars since `reviews:v1` does not access the ratings service.
 
 **Note**: Replace `GATEWAY_HOST_PORT` above with the host and port where
 the Amalgam8 gateway is running in your environment (e.g., `localhost:32000`,
-`<minikube_ip>:32000`, `bookinfo.mybluemix.net`)
+`<minikube_ip>:32000`, `bookinfo.mybluemix.net`).  `<minikube_ip>` can 
+be found by running `echo $(minikube ip)`
 
 ## Content-based routing
 

--- a/_docs/1-demo/helloworld.md
+++ b/_docs/1-demo/helloworld.md
@@ -117,7 +117,7 @@ version "v1" and the other two belong to version "v2".
 
    **Note**: Replace `GATEWAY_HOST_PORT` above with the host and port where
    the Amalgam8 gateway is running in your environment (e.g., `localhost:32000`,
-   `<minikube_ip>:32000`, `helloworld.mybluemix.net`)
+   `$(minikube ip):32000`, `helloworld.mybluemix.net`)
 
    You can see that the traffic is continually routed between the v1 instances only, in a random fashion:
 


### PR DESCRIPTION
Instead of saying "use <minikube_ip>:3200", use the minikube variable so the user can just copy/paste into the commandline.